### PR TITLE
SKILZ-48: URL Auto-Detection for skilz install

### DIFF
--- a/src/skilz/commands/install_cmd.py
+++ b/src/skilz/commands/install_cmd.py
@@ -9,6 +9,29 @@ from skilz.agents import AgentType
 from skilz.errors import SkilzError
 
 
+def is_git_url(skill_id: str | None) -> bool:
+    """Detect if skill_id is a Git URL that should route to git installation.
+
+    Detects:
+    - HTTPS URLs: https://github.com/owner/repo
+    - HTTP URLs: http://github.com/owner/repo
+    - SSH URLs: git@github.com:owner/repo
+    - .git suffix: any URL ending in .git
+
+    Does NOT match:
+    - Registry shorthand: owner/repo
+    - Plain skill names: my-skill
+    """
+    if not skill_id:
+        return False
+    return (
+        skill_id.startswith("https://")
+        or skill_id.startswith("http://")
+        or skill_id.startswith("git@")
+        or skill_id.endswith(".git")
+    )
+
+
 def cmd_install(args: argparse.Namespace) -> int:
     """
     Handle the install command.
@@ -31,6 +54,12 @@ def cmd_install(args: argparse.Namespace) -> int:
     # Handle source options
     file_path: str | None = getattr(args, "file", None)
     git_url: str | None = getattr(args, "git", None)
+
+    # AUTO-DETECT GIT URLs (SKILZ-48)
+    # If skill_id looks like a URL, treat it as git installation
+    if skill_id and is_git_url(skill_id) and not git_url:
+        git_url = skill_id
+        skill_id = None
 
     # Validate source - exactly one of skill_id, -f, or -g must be provided
     sources = [s for s in [skill_id, file_path, git_url] if s is not None]

--- a/tests/test_install_cmd.py
+++ b/tests/test_install_cmd.py
@@ -3,7 +3,7 @@
 import argparse
 from unittest.mock import patch
 
-from skilz.commands.install_cmd import cmd_install
+from skilz.commands.install_cmd import cmd_install, is_git_url
 from skilz.errors import GitError, InstallError, SkillNotFoundError
 
 
@@ -341,3 +341,148 @@ class TestCmdInstall:
         captured = capsys.readouterr()
         # Should get a git clone error for non-existent repo
         assert "git clone failed" in captured.err.lower() or "error" in captured.err.lower()
+
+
+class TestIsGitUrl:
+    """Tests for URL auto-detection (SKILZ-48)."""
+
+    def test_https_github_url(self):
+        """HTTPS GitHub URLs should be detected."""
+        assert is_git_url("https://github.com/owner/repo") is True
+        assert is_git_url("https://github.com/anthropics/skills") is True
+
+    def test_http_url(self):
+        """HTTP URLs should be detected."""
+        assert is_git_url("http://github.com/owner/repo") is True
+
+    def test_ssh_url(self):
+        """SSH URLs should be detected."""
+        assert is_git_url("git@github.com:owner/repo") is True
+        assert is_git_url("git@github.com:owner/repo.git") is True
+
+    def test_dot_git_suffix(self):
+        """URLs ending in .git should be detected."""
+        assert is_git_url("https://github.com/owner/repo.git") is True
+        assert is_git_url("git@gitlab.com:owner/repo.git") is True
+
+    def test_registry_shorthand_not_url(self):
+        """Registry shorthand should NOT be detected as URL."""
+        assert is_git_url("owner/repo") is False
+        assert is_git_url("anthropics_skills/excel") is False
+
+    def test_plain_skill_name_not_url(self):
+        """Plain skill names should NOT be detected as URL."""
+        assert is_git_url("my-skill") is False
+        assert is_git_url("excel") is False
+
+    def test_none_returns_false(self):
+        """None input should return False."""
+        assert is_git_url(None) is False
+
+    def test_empty_string_returns_false(self):
+        """Empty string should return False."""
+        assert is_git_url("") is False
+
+
+class TestUrlAutoDetection:
+    """Tests for URL auto-detection in cmd_install (SKILZ-48)."""
+
+    def test_https_url_routes_to_git_install(self, capsys):
+        """HTTPS URL in skill_id should route to git installation."""
+        args = argparse.Namespace(
+            skill_id="https://github.com/owner/skill-repo",
+            agent=None,
+            project=True,
+            verbose=False,
+            file=None,
+            git=None,  # Not using -g flag
+            copy=False,
+            symlink=False,
+            version_spec=None,
+            install_all=False,
+            yes_all=False,
+            skill=None,
+        )
+
+        with patch("skilz.git_install.install_from_git") as mock_git_install:
+            mock_git_install.return_value = 0
+            result = cmd_install(args)
+
+        assert result == 0
+        mock_git_install.assert_called_once()
+        call_args = mock_git_install.call_args[1]
+        assert call_args["git_url"] == "https://github.com/owner/skill-repo"
+
+    def test_ssh_url_routes_to_git_install(self, capsys):
+        """SSH URL in skill_id should route to git installation."""
+        args = argparse.Namespace(
+            skill_id="git@github.com:owner/skill-repo.git",
+            agent=None,
+            project=True,
+            verbose=False,
+            file=None,
+            git=None,
+            copy=False,
+            symlink=False,
+            version_spec=None,
+            install_all=False,
+            yes_all=False,
+            skill=None,
+        )
+
+        with patch("skilz.git_install.install_from_git") as mock_git_install:
+            mock_git_install.return_value = 0
+            result = cmd_install(args)
+
+        assert result == 0
+        mock_git_install.assert_called_once()
+        call_args = mock_git_install.call_args[1]
+        assert call_args["git_url"] == "git@github.com:owner/skill-repo.git"
+
+    def test_explicit_git_flag_takes_precedence(self):
+        """Explicit -g flag should take precedence over URL detection."""
+        args = argparse.Namespace(
+            skill_id=None,
+            agent=None,
+            project=True,
+            verbose=False,
+            file=None,
+            git="https://github.com/explicit/repo",  # Using -g flag
+            copy=False,
+            symlink=False,
+            version_spec=None,
+            install_all=False,
+            yes_all=False,
+            skill=None,
+        )
+
+        with patch("skilz.git_install.install_from_git") as mock_git_install:
+            mock_git_install.return_value = 0
+            result = cmd_install(args)
+
+        assert result == 0
+        mock_git_install.assert_called_once()
+        call_args = mock_git_install.call_args[1]
+        assert call_args["git_url"] == "https://github.com/explicit/repo"
+
+    def test_registry_id_still_works(self):
+        """Registry skill IDs should still route to registry install."""
+        args = argparse.Namespace(
+            skill_id="anthropics/excel",
+            agent=None,
+            project=True,
+            verbose=False,
+            file=None,
+            git=None,
+            copy=False,
+            symlink=False,
+            version_spec=None,
+        )
+
+        with patch("skilz.installer.install_skill") as mock_install:
+            result = cmd_install(args)
+
+        assert result == 0
+        mock_install.assert_called_once()
+        call_args = mock_install.call_args[1]
+        assert call_args["skill_id"] == "anthropics/excel"


### PR DESCRIPTION
## Summary
Adds automatic detection of Git URLs in `skilz install` command so users don't need the `-g` flag.

## Changes
- Added `is_git_url()` helper function in `install_cmd.py`
- Modified `cmd_install()` to route URLs to git installation
- Added test coverage for all URL patterns

## Test Plan
- [x] `skilz install https://github.com/owner/repo` → git install
- [x] `skilz install git@github.com:owner/repo.git` → git install
- [x] `skilz install http://github.com/owner/repo` → git install
- [x] `skilz install my-skill` → registry lookup (unchanged)
- [x] `skilz install owner/repo` → registry lookup (unchanged)

## Quality
- [x] All 501 tests pass
- [x] `ruff check` passes
- [x] `mypy` passes

Closes SKILZ-48