### PR TITLE
feat(SKILZ-49): Skip config sync for native agents

### DIFF
--- a/src/skilz/cli.py
+++ b/src/skilz/cli.py
@@ -150,6 +150,12 @@ Supported agents: {", ".join(agent_choices)}
         metavar="NAME",
         help="Install specific skill by name from multi-skill repository (with -g/--git)",
     )
+    install_parser.add_argument(
+        "--force-config",
+        action="store_true",
+        dest="force_config",
+        help="Force config file updates even for agents with native skill support",
+    )
 
     # List command
     list_parser = subparsers.add_parser(

--- a/src/skilz/commands/install_cmd.py
+++ b/src/skilz/commands/install_cmd.py
@@ -27,6 +27,7 @@ def cmd_install(args: argparse.Namespace) -> int:
     project_level: bool = getattr(args, "project", False)
     skill_id: str | None = getattr(args, "skill_id", None)
     version_spec: str | None = getattr(args, "version_spec", None)
+    force_config: bool = getattr(args, "force_config", False)
 
     # Handle source options
     file_path: str | None = getattr(args, "file", None)
@@ -57,6 +58,7 @@ def cmd_install(args: argparse.Namespace) -> int:
                 project_level=project_level,
                 verbose=verbose,
                 mode=mode,
+                force_config=force_config,
             )
             return 0
         except SkilzError as e:
@@ -82,6 +84,7 @@ def cmd_install(args: argparse.Namespace) -> int:
             install_all=install_all,
             yes_all=yes_all,
             skill_filter_name=skill_filter_name,
+            force_config=force_config,
         )
 
     try:
@@ -92,6 +95,7 @@ def cmd_install(args: argparse.Namespace) -> int:
             verbose=verbose,
             mode=mode,
             version_spec=version_spec,
+            force_config=force_config,
         )
         return 0
     except SkilzError as e:

--- a/src/skilz/git_install.py
+++ b/src/skilz/git_install.py
@@ -271,6 +271,7 @@ def install_from_git(
     install_all: bool = False,
     yes_all: bool = False,
     skill_filter_name: str | None = None,
+    force_config: bool = False,
 ) -> int:
     """
     Install skill(s) from a git repository URL.
@@ -284,6 +285,7 @@ def install_from_git(
         install_all: If True, install all skills without prompting.
         yes_all: If True (global -y flag), install all without prompting.
         skill_filter_name: If provided, install only the skill with this name.
+        force_config: If True, write to config files even for native agents.
 
     Returns:
         Exit code (0 for success, non-zero for error).
@@ -370,6 +372,7 @@ def install_from_git(
                     git_sha=head_sha,
                     # Use skill name from SKILL.md frontmatter
                     skill_name=skill.skill_name,
+                    force_config=force_config,
                 )
 
                 installed_count += 1

--- a/src/skilz/installer.py
+++ b/src/skilz/installer.py
@@ -4,6 +4,7 @@ import shutil
 from pathlib import Path
 from typing import cast
 
+from skilz.agent_registry import get_registry
 from skilz.agents import (
     AgentType,
     detect_agent,
@@ -94,6 +95,7 @@ def install_local_skill(
     git_url: str | None = None,
     git_sha: str | None = None,
     skill_name: str | None = None,
+    force_config: bool = False,
 ) -> None:
     """
     Install a skill from a local directory.
@@ -107,6 +109,7 @@ def install_local_skill(
         git_url: Optional git repo URL for manifest (overrides "local" default).
         git_sha: Optional git SHA for manifest (overrides "local" default).
         skill_name: Optional skill name (overrides source_path.name, used for git installs).
+        force_config: If True, write to config files even for native agents.
     """
     source_path = source_path.expanduser().resolve()
 
@@ -170,32 +173,45 @@ def install_local_skill(
 
     # Step 5: Sync skill reference to agent config files (project-level only)
     if project_level:
-        project_dir = Path.cwd()
-        ref_skill_id = f"git/{skill_name}" if is_git_source else skill_id
-        skill_ref = SkillReference(
-            skill_id=ref_skill_id,
-            skill_name=skill_name,
-            skill_path=target_dir,
-        )
+        # Check if agent has native skill support (SKILZ-49)
+        registry = get_registry()
+        agent_config = registry.get_or_raise(resolved_agent)
 
-        if verbose:
-            print("Syncing skill to config files...")
+        # Skip config sync for native agents unless --force-config
+        should_sync = force_config or agent_config.native_skill_support == "none"
 
-        sync_results = sync_skill_to_configs(
-            skill=skill_ref,
-            project_dir=project_dir,
-            agent=resolved_agent if agent else None,
-            verbose=verbose,
-        )
+        if not should_sync:
+            if verbose:
+                print(
+                    f"  Skipping config sync ({agent_config.display_name} has native skill support)"
+                )
+        else:
+            project_dir = Path.cwd()
+            ref_skill_id = f"git/{skill_name}" if is_git_source else skill_id
+            skill_ref = SkillReference(
+                skill_id=ref_skill_id,
+                skill_name=skill_name,
+                skill_path=target_dir,
+            )
 
-        for result in sync_results:
-            if result.error:
-                print(f"  Warning: Could not update {result.config_file}: {result.error}")
-            elif result.created:
-                print(f"  Created: {result.config_file}")
-            elif result.updated:
-                if verbose:
-                    print(f"  Updated: {result.config_file}")
+            if verbose:
+                print("Syncing skill to config files...")
+
+            sync_results = sync_skill_to_configs(
+                skill=skill_ref,
+                project_dir=project_dir,
+                agent=resolved_agent if agent else None,
+                verbose=verbose,
+            )
+
+            for result in sync_results:
+                if result.error:
+                    print(f"  Warning: Could not update {result.config_file}: {result.error}")
+                elif result.created:
+                    print(f"  Created: {result.config_file}")
+                elif result.updated:
+                    if verbose:
+                        print(f"  Updated: {result.config_file}")
 
 
 def install_skill(
@@ -205,6 +221,7 @@ def install_skill(
     verbose: bool = False,
     mode: InstallMode | None = None,
     version_spec: str | None = None,
+    force_config: bool = False,
 ) -> None:
     """
     Install a skill from the registry.
@@ -223,6 +240,7 @@ def install_skill(
               - "branch:NAME": Latest commit from specified branch
               - 40-char hex: Specific commit SHA
               - Other: Treat as tag (tries "X" and "vX" formats)
+        force_config: If True, write to config files even for native agents.
 
     Raises:
         SkillNotFoundError: If the skill ID is not found in any registry.
@@ -426,31 +444,44 @@ def install_skill(
 
     # Step 11: Sync skill reference to agent config files (project-level only)
     if project_level:
-        project_dir = Path.cwd()
-        skill_ref = SkillReference(
-            skill_id=skill_info.skill_id,
-            skill_name=skill_info.skill_name,
-            skill_path=target_dir,
-        )
+        # Check if agent has native skill support (SKILZ-49)
+        registry = get_registry()
+        agent_config = registry.get_or_raise(resolved_agent)
 
-        if verbose:
-            print("Syncing skill to config files...")
+        # Skip config sync for native agents unless --force-config
+        should_sync = force_config or agent_config.native_skill_support == "none"
 
-        # If agent was explicitly specified, only update that agent's config
-        # Otherwise, update all existing config files in the project
-        sync_results = sync_skill_to_configs(
-            skill=skill_ref,
-            project_dir=project_dir,
-            agent=resolved_agent if agent else None,
-            verbose=verbose,
-        )
+        if not should_sync:
+            if verbose:
+                print(
+                    f"  Skipping config sync ({agent_config.display_name} has native skill support)"
+                )
+        else:
+            project_dir = Path.cwd()
+            skill_ref = SkillReference(
+                skill_id=skill_info.skill_id,
+                skill_name=skill_info.skill_name,
+                skill_path=target_dir,
+            )
 
-        # Report what was updated
-        for result in sync_results:
-            if result.error:
-                print(f"  Warning: Could not update {result.config_file}: {result.error}")
-            elif result.created:
-                print(f"  Created: {result.config_file}")
-            elif result.updated:
-                if verbose:
-                    print(f"  Updated: {result.config_file}")
+            if verbose:
+                print("Syncing skill to config files...")
+
+            # If agent was explicitly specified, only update that agent's config
+            # Otherwise, update all existing config files in the project
+            sync_results = sync_skill_to_configs(
+                skill=skill_ref,
+                project_dir=project_dir,
+                agent=resolved_agent if agent else None,
+                verbose=verbose,
+            )
+
+            # Report what was updated
+            for result in sync_results:
+                if result.error:
+                    print(f"  Warning: Could not update {result.config_file}: {result.error}")
+                elif result.created:
+                    print(f"  Created: {result.config_file}")
+                elif result.updated:
+                    if verbose:
+                        print(f"  Updated: {result.config_file}")

--- a/tests/test_install_cmd.py
+++ b/tests/test_install_cmd.py
@@ -35,6 +35,7 @@ class TestCmdInstall:
             verbose=False,
             mode=None,
             version_spec=None,
+            force_config=False,
         )
 
     def test_install_with_agent(self):
@@ -62,6 +63,7 @@ class TestCmdInstall:
             verbose=True,
             mode=None,
             version_spec=None,
+            force_config=False,
         )
 
     def test_install_with_claude_agent(self):
@@ -89,6 +91,7 @@ class TestCmdInstall:
             verbose=False,
             mode=None,
             version_spec=None,
+            force_config=False,
         )
 
     def test_install_skill_not_found_error(self, capsys):
@@ -202,6 +205,7 @@ class TestCmdInstall:
             verbose=False,
             mode=None,
             version_spec=None,
+            force_config=False,
         )
 
     def test_install_with_copy_flag(self):
@@ -229,6 +233,7 @@ class TestCmdInstall:
             verbose=False,
             mode="copy",
             version_spec=None,
+            force_config=False,
         )
 
     def test_install_with_symlink_flag(self):
@@ -256,6 +261,7 @@ class TestCmdInstall:
             verbose=False,
             mode="symlink",
             version_spec=None,
+            force_config=False,
         )
 
     def test_install_no_source_error(self, capsys):

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -571,3 +571,160 @@ class TestInstallMode:
             manifest = mock_write.call_args[0][1]
             assert hasattr(manifest, "install_mode")
             assert manifest.install_mode == "copy"
+
+
+class TestConfigSyncSkip:
+    """Tests for SKILZ-49: Skip config sync for native agents."""
+
+    @pytest.fixture
+    def mock_skill_info(self):
+        """Create a mock SkillInfo for testing."""
+        return SkillInfo(
+            skill_id="test/skill",
+            git_repo="https://github.com/test/repo.git",
+            skill_path="/main/skills/test-skill",
+            git_sha="abc123def456789012345678901234567890abcd",
+        )
+
+    @pytest.fixture
+    def mock_dependencies(self, temp_dir, mock_skill_info):
+        """Set up common mocks for install_skill."""
+        cache_path = temp_dir / "cache" / "repo"
+        cache_path.mkdir(parents=True)
+
+        source_path = cache_path / "skills" / "test-skill"
+        source_path.mkdir(parents=True)
+        (source_path / "SKILL.md").write_text("# Test Skill")
+
+        skills_dir = temp_dir / ".claude" / "skills"
+        skills_dir.mkdir(parents=True)
+
+        return {
+            "cache_path": cache_path,
+            "source_path": source_path,
+            "skills_dir": skills_dir,
+            "skill_info": mock_skill_info,
+            "temp_dir": temp_dir,
+        }
+
+    def test_skip_config_sync_for_claude(self, mock_dependencies, capsys):
+        """Config sync should be skipped for Claude (native_skill_support='all')."""
+        deps = mock_dependencies
+
+        with (
+            patch("skilz.installer.detect_agent", return_value="claude"),
+            patch("skilz.installer.get_agent_display_name", return_value="Claude Code"),
+            patch("skilz.installer.get_agent_default_mode", return_value="copy"),
+            patch("skilz.installer.lookup_skill", return_value=deps["skill_info"]),
+            patch("skilz.installer.ensure_skills_dir", return_value=deps["skills_dir"]),
+            patch("skilz.installer.needs_install", return_value=(True, "not_installed")),
+            patch("skilz.installer.clone_or_fetch", return_value=deps["cache_path"]),
+            patch("skilz.installer.parse_skill_path", return_value=("main", "skills/test-skill")),
+            patch("skilz.installer.checkout_sha"),
+            patch("skilz.installer.get_skill_source_path", return_value=deps["source_path"]),
+            patch("skilz.installer.write_manifest"),
+            patch("skilz.installer.sync_skill_to_configs") as mock_sync,
+        ):
+            install_skill("test/skill", project_level=True, verbose=True)
+
+            # Sync should NOT be called for Claude (native support)
+            mock_sync.assert_not_called()
+
+        captured = capsys.readouterr()
+        assert "Skipping config sync" in captured.out
+
+    def test_force_config_overrides_native_support(self, mock_dependencies, capsys):
+        """--force-config should trigger sync even for native agents."""
+        deps = mock_dependencies
+
+        with (
+            patch("skilz.installer.detect_agent", return_value="claude"),
+            patch("skilz.installer.get_agent_display_name", return_value="Claude Code"),
+            patch("skilz.installer.get_agent_default_mode", return_value="copy"),
+            patch("skilz.installer.lookup_skill", return_value=deps["skill_info"]),
+            patch("skilz.installer.ensure_skills_dir", return_value=deps["skills_dir"]),
+            patch("skilz.installer.needs_install", return_value=(True, "not_installed")),
+            patch("skilz.installer.clone_or_fetch", return_value=deps["cache_path"]),
+            patch("skilz.installer.parse_skill_path", return_value=("main", "skills/test-skill")),
+            patch("skilz.installer.checkout_sha"),
+            patch("skilz.installer.get_skill_source_path", return_value=deps["source_path"]),
+            patch("skilz.installer.write_manifest"),
+            patch("skilz.installer.sync_skill_to_configs") as mock_sync,
+        ):
+            mock_sync.return_value = []
+
+            install_skill("test/skill", project_level=True, force_config=True)
+
+            # Sync SHOULD be called with --force-config
+            mock_sync.assert_called_once()
+
+    def test_config_sync_for_gemini(self, mock_dependencies, capsys):
+        """Config sync should happen for Gemini (native_skill_support='none')."""
+        deps = mock_dependencies
+
+        with (
+            patch("skilz.installer.detect_agent", return_value="gemini"),
+            patch("skilz.installer.get_agent_display_name", return_value="Gemini CLI"),
+            patch("skilz.installer.get_agent_default_mode", return_value="copy"),
+            patch("skilz.installer.supports_home_install", return_value=False),
+            patch("skilz.installer.lookup_skill", return_value=deps["skill_info"]),
+            patch("skilz.installer.ensure_skills_dir", return_value=deps["skills_dir"]),
+            patch("skilz.installer.needs_install", return_value=(True, "not_installed")),
+            patch("skilz.installer.clone_or_fetch", return_value=deps["cache_path"]),
+            patch("skilz.installer.parse_skill_path", return_value=("main", "skills/test-skill")),
+            patch("skilz.installer.checkout_sha"),
+            patch("skilz.installer.get_skill_source_path", return_value=deps["source_path"]),
+            patch("skilz.installer.write_manifest"),
+            patch("skilz.installer.sync_skill_to_configs") as mock_sync,
+        ):
+            mock_sync.return_value = []
+
+            install_skill("test/skill", agent="gemini", project_level=True)
+
+            # Sync SHOULD be called for Gemini (no native support)
+            mock_sync.assert_called_once()
+
+    def test_local_skill_skip_config_sync_for_claude(self, temp_dir, capsys):
+        """Local skill install should skip config sync for Claude."""
+        source = temp_dir / "my-skill"
+        source.mkdir()
+        (source / "SKILL.md").write_text("# My Skill")
+
+        skills_dir = temp_dir / ".claude" / "skills"
+        skills_dir.mkdir(parents=True)
+
+        with (
+            patch("skilz.installer.detect_agent", return_value="claude"),
+            patch("skilz.installer.ensure_skills_dir", return_value=skills_dir),
+            patch("skilz.installer.write_manifest"),
+            patch("skilz.installer.sync_skill_to_configs") as mock_sync,
+        ):
+            install_local_skill(source, project_level=True, verbose=True)
+
+            # Sync should NOT be called
+            mock_sync.assert_not_called()
+
+        captured = capsys.readouterr()
+        assert "Skipping config sync" in captured.out
+
+    def test_local_skill_force_config_overrides(self, temp_dir):
+        """Local skill with --force-config should sync for Claude."""
+        source = temp_dir / "my-skill"
+        source.mkdir()
+        (source / "SKILL.md").write_text("# My Skill")
+
+        skills_dir = temp_dir / ".claude" / "skills"
+        skills_dir.mkdir(parents=True)
+
+        with (
+            patch("skilz.installer.detect_agent", return_value="claude"),
+            patch("skilz.installer.ensure_skills_dir", return_value=skills_dir),
+            patch("skilz.installer.write_manifest"),
+            patch("skilz.installer.sync_skill_to_configs") as mock_sync,
+        ):
+            mock_sync.return_value = []
+
+            install_local_skill(source, project_level=True, force_config=True)
+
+            # Sync SHOULD be called with --force-config
+            mock_sync.assert_called_once()


### PR DESCRIPTION
## Summary
- Skip `sync_skill_to_configs()` for agents with native skill support
- Add `--force-config` flag to override detection

## Changes
- **cli.py**: Added `--force-config` flag to install command
- **installer.py**: Added conditional sync logic based on agent's `native_skill_support`
- **git_install.py**: Pass `force_config` parameter through to `install_local_skill()`
- **install_cmd.py**: Extract and pass `force_config` to all install functions

## Behavior
| Agent | Native Support | Config Sync (default) |
|-------|---------------|----------------------|
| Claude | all | Skip |
| Codex | all | Skip |
| OpenCode | home | Skip |
| Gemini | none | Sync |

Use `--force-config` to always sync regardless of native support.

## Testing
- Added `TestConfigSyncSkip` class with 5 tests
- Updated existing mocks to include `force_config` parameter
- All 494 tests passing

## Related
- Part of Skilz 1.5.0 release
- JIRA: SKILZ-49