### PR TITLE
feat(SKILZ-52): Implement skilz visit command

### DIFF
--- a/src/skilz/cli.py
+++ b/src/skilz/cli.py
@@ -269,6 +269,17 @@ Supported agents: {", ".join(agent_choices)}
         help="Search project-level skills only",
     )
 
+    # Visit command
+    visit_parser = subparsers.add_parser(
+        "visit",
+        help="Open a skill's GitHub page in browser",
+        description="Open a skill's GitHub page in the default browser.",
+    )
+    visit_parser.add_argument(
+        "source",
+        help=("Source to visit: owner/repo, owner/repo/skill, or full https://github.com/... URL"),
+    )
+
     return parser
 
 
@@ -310,6 +321,11 @@ def main(argv: list[str] | None = None) -> int:
         from skilz.commands.read_cmd import cmd_read
 
         return cmd_read(args)
+
+    if args.command == "visit":
+        from skilz.commands.visit_cmd import cmd_visit
+
+        return cmd_visit(args)
 
     # Unknown command (shouldn't happen with subparsers)
     parser.print_help()

--- a/src/skilz/commands/visit_cmd.py
+++ b/src/skilz/commands/visit_cmd.py
@@ -1,0 +1,98 @@
+"""Visit command for opening skill GitHub pages in browser."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import webbrowser
+
+
+def resolve_github_url(source: str) -> str:
+    """
+    Resolve a source identifier to a GitHub URL.
+
+    Args:
+        source: Source identifier in one of these formats:
+            - owner/repo: Basic repository path
+            - owner/repo/path: Path within repository
+            - https://github.com/...: Full URL (pass-through)
+            - http://...: Full URL (pass-through)
+
+    Returns:
+        Full GitHub URL.
+
+    Raises:
+        ValueError: If source format is invalid.
+    """
+    source = source.strip()
+
+    if not source:
+        raise ValueError("Source cannot be empty")
+
+    # Pass through full URLs
+    if source.startswith("https://") or source.startswith("http://"):
+        return source
+
+    # Parse owner/repo format
+    parts = source.split("/")
+
+    if len(parts) < 2:
+        raise ValueError(
+            f"Invalid source format: '{source}'. Expected 'owner/repo' or 'owner/repo/path'"
+        )
+
+    owner = parts[0]
+    repo = parts[1]
+
+    if not owner or not repo:
+        raise ValueError("Invalid source: owner and repo cannot be empty")
+
+    # Basic owner/repo
+    if len(parts) == 2:
+        return f"https://github.com/{owner}/{repo}"
+
+    # owner/repo/path - link to tree view
+    path = "/".join(parts[2:])
+    return f"https://github.com/{owner}/{repo}/tree/main/{path}"
+
+
+def open_in_browser(url: str) -> bool:
+    """
+    Open a URL in the default browser.
+
+    Args:
+        url: URL to open.
+
+    Returns:
+        True if browser was opened successfully, False otherwise.
+    """
+    try:
+        return webbrowser.open(url)
+    except Exception:
+        return False
+
+
+def cmd_visit(args: argparse.Namespace) -> int:
+    """Execute the visit command.
+
+    Args:
+        args: Parsed command-line arguments.
+
+    Returns:
+        Exit code (0 for success, 1 for error).
+    """
+    source = args.source
+
+    try:
+        url = resolve_github_url(source)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Opening: {url}")
+
+    if not open_in_browser(url):
+        print("Warning: Could not open browser", file=sys.stderr)
+        print(f"URL: {url}")
+
+    return 0

--- a/tests/test_visit_cmd.py
+++ b/tests/test_visit_cmd.py
@@ -1,0 +1,204 @@
+"""Tests for the visit command."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from skilz.commands.visit_cmd import cmd_visit, open_in_browser, resolve_github_url
+
+
+class TestResolveGithubUrl:
+    """Tests for URL resolution."""
+
+    def test_owner_repo_format(self):
+        """owner/repo should resolve to GitHub URL."""
+        url = resolve_github_url("anthropics/skills")
+        assert url == "https://github.com/anthropics/skills"
+
+    def test_owner_repo_path_format(self):
+        """owner/repo/path should resolve to tree URL."""
+        url = resolve_github_url("anthropics/skills/excel")
+        assert url == "https://github.com/anthropics/skills/tree/main/excel"
+
+    def test_nested_path(self):
+        """Deep paths should work."""
+        url = resolve_github_url("owner/repo/path/to/skill")
+        assert url == "https://github.com/owner/repo/tree/main/path/to/skill"
+
+    def test_https_passthrough(self):
+        """HTTPS URLs should pass through."""
+        input_url = "https://github.com/owner/repo"
+        assert resolve_github_url(input_url) == input_url
+
+    def test_http_passthrough(self):
+        """HTTP URLs should pass through."""
+        input_url = "http://github.com/owner/repo"
+        assert resolve_github_url(input_url) == input_url
+
+    def test_empty_raises_error(self):
+        """Empty source should raise ValueError."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            resolve_github_url("")
+
+    def test_whitespace_only_raises_error(self):
+        """Whitespace-only source should raise ValueError."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            resolve_github_url("   ")
+
+    def test_single_part_raises_error(self):
+        """Single-part source should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid source format"):
+            resolve_github_url("just-one-part")
+
+    def test_whitespace_handled(self):
+        """Leading/trailing whitespace should be handled."""
+        url = resolve_github_url("  owner/repo  ")
+        assert url == "https://github.com/owner/repo"
+
+    def test_empty_owner_raises_error(self):
+        """Empty owner should raise ValueError."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            resolve_github_url("/repo")
+
+    def test_empty_repo_raises_error(self):
+        """Empty repo should raise ValueError."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            resolve_github_url("owner/")
+
+    def test_full_github_url_with_path(self):
+        """Full GitHub URL with path should pass through."""
+        url = "https://github.com/owner/repo/tree/main/skill"
+        assert resolve_github_url(url) == url
+
+
+class TestOpenInBrowser:
+    """Tests for browser opening."""
+
+    @patch("skilz.commands.visit_cmd.webbrowser.open")
+    def test_opens_url(self, mock_open):
+        """Should call webbrowser.open with URL."""
+        mock_open.return_value = True
+        result = open_in_browser("https://example.com")
+        assert result is True
+        mock_open.assert_called_once_with("https://example.com")
+
+    @patch("skilz.commands.visit_cmd.webbrowser.open")
+    def test_returns_false_on_browser_failure(self, mock_open):
+        """Should return False when webbrowser.open returns False."""
+        mock_open.return_value = False
+        result = open_in_browser("https://example.com")
+        assert result is False
+
+    @patch("skilz.commands.visit_cmd.webbrowser.open")
+    def test_handles_exception(self, mock_open):
+        """Should return False on exception."""
+        mock_open.side_effect = Exception("Browser failed")
+        result = open_in_browser("https://example.com")
+        assert result is False
+
+
+class TestCmdVisit:
+    """Tests for cmd_visit function."""
+
+    @patch("skilz.commands.visit_cmd.open_in_browser")
+    def test_success(self, mock_browser, capsys):
+        """Should open resolved URL in browser."""
+        mock_browser.return_value = True
+
+        args = MagicMock()
+        args.source = "owner/repo"
+
+        result = cmd_visit(args)
+
+        assert result == 0
+        mock_browser.assert_called_once_with("https://github.com/owner/repo")
+        captured = capsys.readouterr()
+        assert "Opening: https://github.com/owner/repo" in captured.out
+
+    @patch("skilz.commands.visit_cmd.open_in_browser")
+    def test_with_path(self, mock_browser, capsys):
+        """Should handle owner/repo/path format."""
+        mock_browser.return_value = True
+
+        args = MagicMock()
+        args.source = "owner/repo/skill"
+
+        result = cmd_visit(args)
+
+        assert result == 0
+        mock_browser.assert_called_once_with("https://github.com/owner/repo/tree/main/skill")
+
+    @patch("skilz.commands.visit_cmd.open_in_browser")
+    def test_with_full_url(self, mock_browser, capsys):
+        """Should handle full URL."""
+        mock_browser.return_value = True
+
+        args = MagicMock()
+        args.source = "https://github.com/owner/repo"
+
+        result = cmd_visit(args)
+
+        assert result == 0
+        mock_browser.assert_called_once_with("https://github.com/owner/repo")
+
+    def test_invalid_source_returns_error(self, capsys):
+        """Should return 1 and print error for invalid source."""
+        args = MagicMock()
+        args.source = "invalid"
+
+        result = cmd_visit(args)
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Error:" in captured.err
+        assert "Invalid source format" in captured.err
+
+    @patch("skilz.commands.visit_cmd.open_in_browser")
+    def test_browser_failure_warning(self, mock_browser, capsys):
+        """Should show warning when browser fails to open."""
+        mock_browser.return_value = False
+
+        args = MagicMock()
+        args.source = "owner/repo"
+
+        result = cmd_visit(args)
+
+        assert result == 0  # Still returns success
+        captured = capsys.readouterr()
+        assert "Warning: Could not open browser" in captured.err
+        assert "https://github.com/owner/repo" in captured.out
+
+
+class TestCLIIntegration:
+    """Tests for CLI integration of visit command."""
+
+    def test_visit_command_registered(self):
+        """Visit command should be registered in CLI."""
+        from skilz.cli import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["visit", "owner/repo"])
+        assert args.command == "visit"
+        assert args.source == "owner/repo"
+
+    @patch("skilz.commands.visit_cmd.open_in_browser")
+    def test_main_routes_to_visit(self, mock_browser, capsys):
+        """main() should route visit command to cmd_visit."""
+        from skilz.cli import main
+
+        mock_browser.return_value = True
+
+        result = main(["visit", "owner/repo"])
+
+        assert result == 0
+        mock_browser.assert_called_once()
+
+    def test_visit_invalid_source_via_main(self, capsys):
+        """main() should handle invalid source."""
+        from skilz.cli import main
+
+        result = main(["visit", "invalid"])
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Error" in captured.err


### PR DESCRIPTION
## Summary
Implements the `skilz visit` command for opening skill GitHub pages in browser.

## Changes
- Created `src/skilz/commands/visit_cmd.py` with URL resolution
- Added CLI command with source argument
- Supports multiple input formats
- Added 23 comprehensive tests

## Usage
```bash
skilz visit anthropics/skills          # Opens repo
skilz visit anthropics/skills/excel    # Opens skill in repo
skilz visit https://github.com/...     # Opens full URL
```

## URL Resolution
| Input | Resolved URL |
|-------|--------------|
| `owner/repo` | `https://github.com/owner/repo` |
| `owner/repo/skill` | `https://github.com/owner/repo/tree/main/skill` |
| `https://...` | Pass through unchanged |

## Test Plan
- [x] `skilz visit --help` shows usage
- [x] owner/repo format opens correct URL
- [x] owner/repo/path format opens tree URL
- [x] Full URLs pass through
- [x] Invalid sources show error
- [x] All 512 tests passing

## Quality
- [x] All tests pass
- [x] 23 new tests added

Closes SKILZ-52